### PR TITLE
ENABLE ORIGINAL FILE DUMP IN VERSION HDR FILE WRAPPER FOR BKWDCOMP

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -133,6 +133,7 @@ if (BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
     hipfft-version.h hipfft-export.h
     GUARDS SYMLINK WRAPPER
     WRAPPER_LOCATIONS include hipfft/include
+    ORIGINAL_FILES ${PROJECT_BINARY_DIR}/include/hipfft/hipfft-version.h
   )
 endif( )
 


### PR DESCRIPTION
resolves #___

Summary of proposed changes:
-  
-  
-  
